### PR TITLE
Update cpp-common tool versions

### DIFF
--- a/cpp-common/22.04/Dockerfile
+++ b/cpp-common/22.04/Dockerfile
@@ -2,8 +2,8 @@ FROM kubasejdak/base:22.04
 
 # Settings.
 ARG CLANG_FORMAT_VERSION=14
-ARG CMAKE_VERSION=4.0.3
-ARG CONAN_VERSION=2.18.1
+ARG CMAKE_VERSION=4.1.1
+ARG CONAN_VERSION=2.20.1
 ARG CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh
 ARG LIBFAKETIME_URL=https://github.com/wolfcw/libfaketime.git
 

--- a/cpp-common/24.04/Dockerfile
+++ b/cpp-common/24.04/Dockerfile
@@ -2,8 +2,8 @@ FROM kubasejdak/base:24.04
 
 # Settings.
 ARG CLANG_FORMAT_VERSION=18
-ARG CMAKE_VERSION=4.0.3
-ARG CONAN_VERSION=2.18.1
+ARG CMAKE_VERSION=4.1.1
+ARG CONAN_VERSION=2.20.1
 ARG CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh
 ARG LIBFAKETIME_URL=https://github.com/wolfcw/libfaketime.git
 


### PR DESCRIPTION
## Summary
- update the CMake installer to version 4.1.1 in the cpp-common images
- bump the Conan tool installation to version 2.20.1 for both Ubuntu 22.04 and 24.04 variants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdc1e07ffc83268e33fcd9cbbca19e